### PR TITLE
[REFACTOR] 페이퍼에서 롤 목록 이동 버튼, 선생님 사용자 페이퍼의 작성자 옆 '선생님' 문자열 추가  

### DIFF
--- a/src/components/MuiIcon.js
+++ b/src/components/MuiIcon.js
@@ -3,6 +3,7 @@ import ShareIcon from '@mui/icons-material/Share';
 import DeleteIcon from '@mui/icons-material/Delete';
 import BorderColorIcon from '@mui/icons-material/BorderColor';
 import LogoutIcon from '@mui/icons-material/Logout';
+import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
 
 //선생님 마잎이지 버튼
 function UrlCopyIcon(props) {
@@ -29,5 +30,11 @@ function UserLogout(props) {
   );
 }
 
+function BackToRollList(props) {
+    return (
+        <ArrowBackIosNewIcon {...props} style={{ cursor: 'pointer' }} />
+    )
+}
+
 // 이름 내보내기
-export { UrlCopyIcon, RollDelete, RollTittleEdit, UserLogout };
+export { UrlCopyIcon, RollDelete, RollTittleEdit, UserLogout, BackToRollList };

--- a/src/components/PaperDetailModal.js
+++ b/src/components/PaperDetailModal.js
@@ -4,7 +4,7 @@ import axios from "axios";
 import { CustomLogout } from "../components/MuiButton";
 
 const PaperDetailModal = ({ paper, closeModal }) => {
-  const { content, authorName, paperId } = paper;
+  const { content, authorName, paperId, authorRole } = paper;
   const [isEditing, setIsEditing] = useState(false); // 수정 모드 상태
   const [newContent, setNewContent] = useState(content);
   const token = localStorage.getItem("Authorization");
@@ -78,9 +78,8 @@ const PaperDetailModal = ({ paper, closeModal }) => {
           e.stopPropagation();
         }}
       >
-        {/* 모달 내용 */}
-        <p style={{ fontWeight: "bold", marginBottom: "10px" }}>
-          From. {authorName}
+        <p style={{ fontWeight: "bold", marginBottom: "10px"}}>
+          From. {`${authorName}${authorRole === "TEACHER" ? " 선생님" : ""}`}
         </p>
         {/* 롤링페이퍼 내용 */}
         {isEditing ? (
@@ -89,11 +88,14 @@ const PaperDetailModal = ({ paper, closeModal }) => {
               type="text"
               value={newContent}
               onChange={(e) => setNewContent(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  handleSave();
-                }
-              }}                 
+              /** 
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    handleSave();
+                  }
+                }}
+                수정 시 다음 줄로 넘어가기 위해서 Enter 누를 시 저장이 되어 보류
+              */                 
             />
             <div className="paper-modal-button">
               <CustomLogout

--- a/src/components/PaperItem.js
+++ b/src/components/PaperItem.js
@@ -6,7 +6,7 @@ const PaperItem = ({ paper }) => {
   const { paperId, content, authorName, authorRole } = paper;
   const [isPaperDetailModalOpen, setIsPaperDetailModalOpen] = useState(false);
 
-  const showPaperDetailModal = (paper) => {
+  const showPaperDetailModal = () => {
     setIsPaperDetailModalOpen(true);
   };
 
@@ -17,10 +17,14 @@ const PaperItem = ({ paper }) => {
   return (
     <>
       <div>
-        <p className="fromName">From. {authorName}</p>
+        {authorRole === "TEACHER" ? (
+          <p className="fromName">From. {`${authorName} 선생님`}</p>
+        ) : (
+          <p className="fromName">From. {authorName}</p>
+        )}
         <div
           key={paperId}
-          onClick={() => showPaperDetailModal(paper)}
+          onClick={() => showPaperDetailModal()}
           className="paper-box"
         >
           <p>{content}</p>

--- a/src/components/RollItem.js
+++ b/src/components/RollItem.js
@@ -5,7 +5,7 @@ import { useNavigate } from "react-router-dom";
 import { UrlCopyIcon, RollDelete, RollTittleEdit } from "./MuiIcon";
 import UpdateRollModal from "../components/UpdateRollModal";
 
-const RollItem = ({ roll }) => {
+const RollItem = ({ roll, role }) => {
   const { rollId, rollName, classCode, url } = roll;
   // 롤 제목 수정 모드 상태를 관리하는 state
   const [isUpdateRollModalOpen, setIsUpdateRollModalOpen] = useState(false);
@@ -15,7 +15,7 @@ const RollItem = ({ roll }) => {
 
     const enterRoll = () => {
         // 해당 rollId에 할당된 paper들을 불러오는 로직이 필요함
-        navigate(`/roll/${url}/join`, { state: { rollId, rollName } })
+        navigate(`/roll/${url}/join`, { state: { rollId, rollName, role } })
         console.log(`롤링페이퍼 ${rollId}로 이동`);
     }
 

--- a/src/components/SocialLogin.js
+++ b/src/components/SocialLogin.js
@@ -21,7 +21,7 @@ const SocialLogin = () => {
 
         // Spring Security로 간소화 적용 후 코드
         // Spring Security가 제공하는 네이버 OAuth2 인증 엔드포인트로 리다이렉트
-        window.location.href = 'http://54.180.134.120/oauth2/authorization/naver';
+        window.location.href = 'http://localhost:8080/oauth2/authorization/naver';
 
     }
     
@@ -38,7 +38,7 @@ const SocialLogin = () => {
 
         // Spring Security로 간소화 적용 후 코드
         // Spring Security가 제공하는 카카오 OAuth2 인증 엔드포인트로 리다이렉트
-        window.location.href = 'http://54.180.134.120/oauth2/authorization/kakao';
+        window.location.href = 'http://localhost:8080/oauth2/authorization/kakao';
         
     }
     

--- a/src/components/StudentSignin.js
+++ b/src/components/StudentSignin.js
@@ -24,7 +24,8 @@ const StudentSignin = ({ url }) => {
           )
           const teacherUserData = teacherUserResponse.data;
           const role = teacherUserData.data.role;
-          
+          if (role !== "TEACHER") return;
+
           const teacherRollResponse = await axios.get(
             "http://localhost:8080/roll/me",
             {
@@ -39,7 +40,7 @@ const StudentSignin = ({ url }) => {
           if (foundItem) {
             const { rollId, rollName } = foundItem;
             navigate(`/roll/${url}/join`, { state: { rollId, rollName, role } });
-          }
+          } else { return; }
         } catch (error) {}
       }
     };

--- a/src/components/StudentSignin.js
+++ b/src/components/StudentSignin.js
@@ -14,27 +14,38 @@ const StudentSignin = ({ url }) => {
     const fetchTeacherData = async () => {
       if (token) {
         try {
-          const userResponse = await axios.get(
+          const teacherUserResponse = await axios.get(
+            "http://localhost:8080/user/profile",
+            {
+              headers: {
+                Authorization: token
+              }
+            }
+          )
+          const teacherUserData = teacherUserResponse.data;
+          const role = teacherUserData.data.role;
+          
+          const teacherRollResponse = await axios.get(
             "http://localhost:8080/roll/me",
             {
               headers: {
                 Authorization: token,
-              },
+              }
             }
           );
-          const userData = userResponse.data;
-          const foundItem = userData.data.find((item) => item.url === url);
+          const teacherRollData = teacherRollResponse.data;
+          const foundItem = teacherRollData.data.find((item) => item.url === url);
 
           if (foundItem) {
             const { rollId, rollName } = foundItem;
-            navigate(`/roll/${url}/join`, { state: { rollId, rollName } });
+            navigate(`/roll/${url}/join`, { state: { rollId, rollName, role } });
           }
         } catch (error) {}
       }
     };
 
     fetchTeacherData();
-  }, [token, url, navigate]);
+  }, [token, url]);
 
   const handleSignin = async (e) => {
     e.preventDefault();
@@ -70,11 +81,12 @@ const StudentSignin = ({ url }) => {
       const refreshToken = studentData.data.refreshToken;
       const rollId = studentData.data.rollId;
       const rollName = studentData.data.rollName;
+      const role = studentData.data.role;
 
       if (studentToken && refreshToken) {
         localStorage.setItem("Authorization", `Bearer ${studentToken}`);
         localStorage.setItem("RefreshToken", refreshToken);
-        navigate(`/roll/${url}/join`, { state: { rollId, rollName } });
+        navigate(`/roll/${url}/join`, { state: { rollId, rollName, role } });
       }
     } catch (error) {
       console.log("토큰 fetch 실패: ", error);

--- a/src/pages/MyPage.js
+++ b/src/pages/MyPage.js
@@ -11,6 +11,7 @@ const MyPage = () => {
     const navigate = useNavigate();
     const [userName, setUserName] = useState("");
     const [rolls, setRolls] = useState([]);
+    const [role, setRole] = useState();
     const [isCreateRollModalOpen, setIsCreateRollModalOpen] = useState(false);
     const token = localStorage.getItem("Authorization");
 
@@ -37,7 +38,8 @@ const MyPage = () => {
 
                 const userData = userResponse.data;
                 console.log("User Info Response:", userData);
-                setUserName(userData.data.name);  // SnResponse 구조에 맞게 수정
+                setUserName(userData.data.name);
+                setRole(userData.data.role);
 
                 // 롤 데이터 가져오기
                 const rollResponse = await axios.get(`http://localhost:8080/roll/me`, {
@@ -64,8 +66,9 @@ const MyPage = () => {
     }, [navigate]);
 
     const teacherlogout = () => {
-        localStorage.removeItem("Authorization");
-        localStorage.removeItem("RefreshToken");
+        // localStorage.removeItem("Authorization");
+        // localStorage.removeItem("RefreshToken");
+        localStorage.clear();
         navigate('/');
     };
 
@@ -89,6 +92,7 @@ const MyPage = () => {
                         <RollItem
                             key={roll.rollId}
                             roll={roll}
+                            role={role}
                         />
                     ))
                 ) : (

--- a/src/pages/RollingPaperPage.js
+++ b/src/pages/RollingPaperPage.js
@@ -63,13 +63,13 @@ const RollingPaperPage = () => {
               onClick={() => navigate(`/mypage`)}
               style={{ fontWeight: "bold", fontSize: "16px"}}
             >
-              학급 목록
+              {"<<"}
             </CustomLogout>
           ) : ("")}
           <p 
             className="className"
             style={{
-              paddingLeft: role === "TEACHER" ? "30px" : "60px",
+              paddingLeft: role === "TEACHER" ? "30px" : "80px",
               paddingRight: role === "TEACHER" ? "30px" : "0"
             }}
           >

--- a/src/pages/RollingPaperPage.js
+++ b/src/pages/RollingPaperPage.js
@@ -8,9 +8,8 @@ import { CustomLogout } from "../components/MuiButton";
 
 const RollingPaperPage = () => {
     const location = useLocation();
-    const { rollId } = location.state || {};
-    const { rollName } = location.state || {};
     const navigate = useNavigate();
+    const { rollId, rollName, role } = location.state || {};
     const [papers, setPapers] = useState([]);
     const [isCreatePaperModalOpen, setIsCreatePaperModalOpen] = useState(false);
     const token = localStorage.getItem("Authorization");
@@ -33,8 +32,6 @@ const RollingPaperPage = () => {
                         },
                     }
                 );
-
-
                 const paperData = paperResponse.data;
                 console.log("Paper Data Response:", paperData);
                 setPapers(paperData.data || []); // 빈 배열 fallback 추가
@@ -44,7 +41,7 @@ const RollingPaperPage = () => {
         }
 
         fetchPaperData();
-    }, [rollId]);
+    }, [rollId, token]);
 
     // 모달을 여는 함수
     const showCreateModal = () => {
@@ -60,7 +57,24 @@ const RollingPaperPage = () => {
     return (
       <div>
         <div className="header">
-          <p className="className">{rollName}</p>
+          {role === "TEACHER" ? (
+            <CustomLogout
+              className="roll-list-button"
+              onClick={() => navigate(`/mypage`)}
+              style={{ fontWeight: "bold", fontSize: "16px"}}
+            >
+              학급 목록
+            </CustomLogout>
+          ) : ("")}
+          <p 
+            className="className"
+            style={{
+              paddingLeft: role === "TEACHER" ? "30px" : "60px",
+              paddingRight: role === "TEACHER" ? "30px" : "0"
+            }}
+          >
+            {rollName}
+          </p>
           <CustomLogout
             className="add-paper-button"
             onClick={showCreateModal}
@@ -73,7 +87,7 @@ const RollingPaperPage = () => {
         <div className="paper-container">
           {/* RollingPaperDetail 컴포넌트 */}
           {Array.isArray(papers) && papers.length > 0 ? (
-            papers.map((paper) => <PaperItem key={paper.paperId} paper={paper} />)
+            papers.map((paper) => <PaperItem key={paper.paperId} paper={paper} role={role}/>)
           ) : (
             <p>작성된 페이퍼가 없습니다</p>
           )}

--- a/src/pages/RollingPaperPage.js
+++ b/src/pages/RollingPaperPage.js
@@ -5,6 +5,7 @@ import CreatePaperModal from "../components/CreatePaperModal";
 import { useLocation, useNavigate } from "react-router-dom";
 import axios from "axios";
 import { CustomLogout } from "../components/MuiButton";
+import { BackToRollList } from "../components/MuiIcon";
 
 const RollingPaperPage = () => {
     const location = useLocation();
@@ -63,7 +64,7 @@ const RollingPaperPage = () => {
               onClick={() => navigate(`/mypage`)}
               style={{ fontWeight: "bold", fontSize: "16px"}}
             >
-              {"<<"}
+              < BackToRollList />
             </CustomLogout>
           ) : ("")}
           <p 

--- a/src/pages/RollingPaperPage.js
+++ b/src/pages/RollingPaperPage.js
@@ -69,7 +69,7 @@ const RollingPaperPage = () => {
           <p 
             className="className"
             style={{
-              paddingLeft: role === "TEACHER" ? "30px" : "80px",
+              paddingLeft: role === "TEACHER" ? "30px" : "100px",
               paddingRight: role === "TEACHER" ? "30px" : "0"
             }}
           >

--- a/src/styles/pages/RollingPaperPage.css
+++ b/src/styles/pages/RollingPaperPage.css
@@ -16,7 +16,7 @@
   font-weight: bold;
   margin: 18px 20px;
   text-align: center;
-  padding-left: 60px;
+  /* padding-left: 60px; /pages/RollingPaperPage.js 내 요소에 직접 반영 */ 
 
   font-family: "Hi Melody", cursive;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #58, #59 

## #️⃣ 작업 내용

> 선생님 사용자가 특정 버튼을 눌렀을 때 페이퍼에서 롤 목록으로 돌아가는 기능 구현
> 선생님 유저가 페이퍼를 작성했을 때 작성자 이름 뒤에 '선생님' 문자열을 추가하는 기능 구현

## #️⃣ 테스트 결과

> 페이퍼에서 롤 목록으로 이동하는 기능, 선생님 사용자의 페이퍼 옆 작성자 이름 옆 '선생님' 문자열 기능 모두 정상 작동

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 필요한 경우, 문서를 작성하거나 수정했나요?
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 선생님 사용자가 페이퍼 목록에 들어갔을 경우
(1) '<' 형태로 롤 목록으로 돌아갈 수 있는 버튼 구현
(2) 선생님 사용자가 작성한 페이퍼는 작성자 이름 옆에 '선생님' 문자열 추가됨
![image](https://github.com/user-attachments/assets/7d801865-24de-4d44-8fea-e68ca8c964e8)

> 학생 사용자가 페이퍼 목록에 들어갔을 경우
(1) '<' 형태로 롤 목록으로 돌아갈 수 있는 버튼 비활성화
(2) 선생님 사용자가 작성한 페이퍼는 작성자 이름 옆에 '선생님' 문자열 확인 가능
![image](https://github.com/user-attachments/assets/21e5ce4e-831b-4ab0-8b54-a2affadc8cac)

> 페이퍼 내용 열람 시 선생님 사용자의 페이퍼에는 작성자 이름 옆에 '선생님' 문자열 추가됨 
![image](https://github.com/user-attachments/assets/b0f8e1bb-b36a-45eb-960b-be96c744075f)
![image](https://github.com/user-attachments/assets/868ebeb6-3a2f-47a6-9765-2e5e70e7176a)


## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
> 예시: 이 부분의 코드가 잘 작동하는지 테스트 해주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요.
