### PR TITLE
[REFACTOR] 배포 환경에 맞춰 API 엔드포인트 도메인 변경

### DIFF
--- a/src/components/CreatePaperModal.js
+++ b/src/components/CreatePaperModal.js
@@ -18,7 +18,7 @@ const CreatePaperModal = ({ rollId, closeModal }) => {
   const handleCreatePaper = async () => {
     try {
       await axios.post(
-        `http://localhost:8080/paper/rolls/${rollId}`,
+        `https://sparklenote.site/paper/rolls/${rollId}`,
         { content: paperContent },
         {
           headers: {

--- a/src/components/CreateRollModal.js
+++ b/src/components/CreateRollModal.js
@@ -15,7 +15,7 @@ const CreateRollModal = ({ closeModal }) => {
 
     const createRoll = async () => {
         try {
-            await axios.post(`http://localhost:8080/roll`, { rollName: rollTitle }, {
+            await axios.post(`https://sparklenote.site/roll`, { rollName: rollTitle }, {
                 headers: {
                     "Authorization": token
                 }

--- a/src/components/PaperDetailModal.js
+++ b/src/components/PaperDetailModal.js
@@ -27,7 +27,7 @@ const PaperDetailModal = ({ paper, closeModal }) => {
     if (newContent !== content) {
       try {
         await axios.put(
-          `http://localhost:8080/paper/${paperId}`,
+          `https://sparklenote.site/paper/${paperId}`,
           { content: newContent },
           {
             headers: {
@@ -52,7 +52,7 @@ const PaperDetailModal = ({ paper, closeModal }) => {
   const handleDelete = async () => {
     if (window.confirm("해당 페이퍼를 삭제하시겠습니까?")) {
       try {
-        await axios.delete(`http://localhost:8080/paper/${paperId}`, {
+        await axios.delete(`https://sparklenote.site/paper/${paperId}`, {
           headers: {
             Authorization: token,
           },

--- a/src/components/RollItem.js
+++ b/src/components/RollItem.js
@@ -21,7 +21,7 @@ const RollItem = ({ roll }) => {
 
   const copyUrl = () => {
     navigator.clipboard
-      .writeText(`http://localhost:3000/${url}`)
+      .writeText(`https://sparklenote.site/${url}`)
       .then(() => {
         alert("URL이 클립보드에 복사되었습니다.");
       })
@@ -42,7 +42,7 @@ const RollItem = ({ roll }) => {
       )
     ) {
       try {
-        await axios.delete(`http://localhost:8080/roll/${rollId}`, {
+        await axios.delete(`https://sparklenote.site/roll/${rollId}`, {
           headers: {
             Authorization: `Bearer ${token}`,
           },

--- a/src/components/StudentSignin.js
+++ b/src/components/StudentSignin.js
@@ -15,7 +15,7 @@ const StudentSignin = ({ url }) => {
       if (token) {
         try {
           const userResponse = await axios.get(
-            "http://localhost:8080/roll/me",
+            "https://sparklenote.site/roll/me",
             {
               headers: {
                 Authorization: token,
@@ -50,7 +50,7 @@ const StudentSignin = ({ url }) => {
       }
       
       const response = await axios.post(
-        `http://localhost:8080/roll/${url}/join`,
+        `https://sparklenote.site/roll/${url}/join`,
         {
           name: studentName,
           classCode: classCode,

--- a/src/components/UpdateRollModal.js
+++ b/src/components/UpdateRollModal.js
@@ -17,7 +17,7 @@ const UpdateRollModal = ({ closeModal, roll }) => {
   const updateRoll = async () => {
     try {
       await axios.put(
-        `http://localhost:8080/roll/${roll.rollId}`,
+        `https://sparklenote.site/roll/${roll.rollId}`,
         { rollName: rollTitle },
         { headers: { Authorization: token } }
       );


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #62 

## #️⃣ 작업 내용

> 배포 환경에 맞춰 API 엔드포인트 도메인 변경 
> 서비스 내 API 호출 URL의 도메인을 모두 'https://sparklenote.site'로 변경

## #️⃣ 테스트 결과

> 로컬 환경이 아닌 배포 환경에서의 실행이므로 위 PR이 병합되기 전에는 작동 여부를 알 수 없음

## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 필요한 경우, 문서를 작성하거나 수정했나요?
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
> 예시: 이 부분의 코드가 잘 작동하는지 테스트 해주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요.
